### PR TITLE
[Fix] 초기 데이터가 없을 시 시간표가 무한 리렌더링되던 오류 수정

### DIFF
--- a/frontend/src/apis/TimeTableAPI.ts
+++ b/frontend/src/apis/TimeTableAPI.ts
@@ -2,6 +2,7 @@ import type { AvailableTimeSlotType } from "@/features/timeTable/TimeTable.type"
 import { clientInstance } from "@/utils/AxiosInstance";
 import type { CustomError } from "@/utils/CustomError";
 import { useMutation, useQuery, useQueryClient } from "@tanstack/react-query";
+import { useEffect } from "react";
 
 export interface TimeSlotAPIResponse {
   isSuccess: boolean;
@@ -19,15 +20,28 @@ export interface TimeSlotAPIResponse {
 export const timeSlotQueryKey = (carId: number, weekKey: string) =>
   ["timeSlot", carId, weekKey] as const;
 
-export const useGetTimeSlot = (selectedCarId: number, weekKey: string) => {
-  const { data, isFetching, error, refetch } = useQuery<TimeSlotAPIResponse>({
-    queryKey: timeSlotQueryKey(selectedCarId, weekKey),
-    queryFn: () =>
-      clientInstance.get(`/rental?car-id=${selectedCarId}&date=${weekKey}`),
-    enabled: selectedCarId > 0,
-    staleTime: 5 * 60 * 1000,
-    gcTime: 30 * 60 * 1000,
-  });
+export const useGetTimeSlot = (
+  selectedCarId: number,
+  weekKey: string,
+  options?: {
+    onSuccess?: (data: TimeSlotAPIResponse) => void;
+  },
+) => {
+  const { data, isFetching, isSuccess, error, refetch } =
+    useQuery<TimeSlotAPIResponse>({
+      queryKey: timeSlotQueryKey(selectedCarId, weekKey),
+      queryFn: () =>
+        clientInstance.get(`/rental?car-id=${selectedCarId}&date=${weekKey}`),
+      enabled: selectedCarId > 0,
+      staleTime: 5 * 60 * 1000,
+      gcTime: 30 * 60 * 1000,
+    });
+
+  useEffect(() => {
+    if (isSuccess && data) {
+      options?.onSuccess?.(data);
+    }
+  }, [isSuccess, data, options?.onSuccess]);
 
   const timeSlotData = data?.data ?? [];
 

--- a/frontend/src/features/timeTable/components/TimeTable.tsx
+++ b/frontend/src/features/timeTable/components/TimeTable.tsx
@@ -76,16 +76,26 @@ const TimeTable = ({
     [selectedCarId, nextWeekKey],
   );
 
+  const handleSuccessGetTimeSlot = useCallback(
+    (response: TimeSlotAPIResponse) => {
+      setTimeSlotsDraft(response.data);
+      setPreviewSlot(null);
+      setShowSlots(true);
+    },
+    [],
+  );
+
   const slotsDisabled = Boolean(previewSlot);
 
   const queryClient = useQueryClient();
   const { createTimeSlot, error: postError } = usePostTimeSlot();
   const {
-    timeSlotData,
     isFetching,
     error: fetchError,
     refetch,
-  } = useGetTimeSlot(selectedCarId, nextWeekKey);
+  } = useGetTimeSlot(selectedCarId, nextWeekKey, {
+    onSuccess: handleSuccessGetTimeSlot,
+  });
 
   // Error 관련 상태
   const activeError = postError ?? fetchError;
@@ -120,14 +130,6 @@ const TimeTable = ({
     });
     return () => window.cancelAnimationFrame(rafId);
   }, [selectedCarId, selectedWeek]);
-
-  // 새로운 데이터가 로드되면 draft 상태 초기화
-  useEffect(() => {
-    if (isFetching || !timeSlotData) return;
-    setTimeSlotsDraft(timeSlotData);
-    setPreviewSlot(null);
-    setShowSlots(true);
-  }, [isFetching, timeSlotData]);
 
   const handleCancelClick = useCallback(() => {
     const cachedSlotData =


### PR DESCRIPTION
## 📝 기능 설명
API 응답이 비정상일 때 빈 배열 처리로 인해 발생하던 무한 리렌더링 문제를 해결

## 🛠 작업 사항
### 1. 문제 상황
- 로컬 환경에서 API 호출 시, CORS 문제로 인해 데이터를 정상적으로 받지 못함
- data ?? [] 방식으로 빈 배열을 기본값으로 사용했는데,
  - 매 렌더링마다 새로운 빈 배열이 생성됨
  - useEffect 의존성에 빈 배열이 포함되어 값이 바뀌었다고 인식
  - 내부에서 setState가 실행되며 빈 배열A -> 빈 배열B로 변경
  - useEffect 의존성에 빈 배열이 포함되어 값이 바뀌었다고 인식 -> 무한 리렌더링 발생
<img width="422" height="241" alt="시간표 무한 렌더링" src="https://github.com/user-attachments/assets/533e6c4e-bfce-41b9-a1d5-be2fa0315030" />

### 2. 해결 방법
- 해결 방안 후보
  - 빈 배열을 useMemo로 메모이제이션
  - 빈 배열 대신 undefined 처리
  - useEffect을 통째로 제거하고 react query의 onSuccess 콜백에서 상태 변경 처리
- 최종 선택: onSuccess 콜백 사용
  - 성공 시점에만 draft state 세팅 -> 불필요한 effect 제거

### 3. 느낀 점
- 내용이 같은 빈 배열이라도 새로 생성하면 참조가 달라져 내부적으론 다른 값으로 인식된다. -> JS의 참조 타입과 참조 동일성 개념 복습
- 애초에 기존 useEffect의 가드 조건이 동작하지 않았다. -> JS에서 []는 truthy이므로 ![]는 false -> 조건문 통과
- react query의 onSuccess 속성을 잘 활용하는 방법을 배웠다. -> v5에서는 useQuery 옵션에 직접 onSuccess를 못넣어서, 성공시 로직을 useEffect 안에서 처리해야 한다는 점을 알게됨

## ✅ 작업 항목
- [x] API 응답 실패 시 무한 리렌더링 원인 제거
- [x] useEffect 제거 후 onSuccess 기반으로 상태 업데이트